### PR TITLE
feat(pionex-wallet): add wallet skill for full portfolio overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```
 skills/
   pionex-market/    → Public market data (no auth required)
-  pionex-portfolio/ → Account balance queries
+  pionex-portfolio/ → Account balance queries (spot coin list)
+  pionex-wallet/    → Full portfolio overview (spot + bots + dual investment, USDT/BTC total)
   pionex-trade/     → Spot order placement, cancellation, fills
   pionex-bot/       → Futures Grid Bot lifecycle (create/adjust/reduce/cancel)
 ```
@@ -52,7 +53,8 @@ metadata:
 | Skill | Scope | Auth |
 |-------|-------|------|
 | `pionex-market` | Market data: depth, tickers, symbols, klines, trades | No |
-| `pionex-portfolio` | Account balance (spot) | Yes |
+| `pionex-portfolio` | Account balance (spot coin list) | Yes |
+| `pionex-wallet` | Full portfolio overview: USDT/BTC total across all account types | Yes |
 | `pionex-trade` | Spot orders: place, cancel, open orders, fills | Yes |
 | `pionex-bot` | Futures Grid Bot lifecycle: get/create/adjust/reduce/cancel | Yes |
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ are enforced for order placement, balance checks, and minimum order sizes.
 |-------|-------------|------|
 | [pionex-market](skills/pionex-market/SKILL.md) | Public market data: depth, tickers, symbols, klines, trades | No |
 | [pionex-portfolio](skills/pionex-portfolio/SKILL.md) | Account balance (spot) | Yes |
+| [pionex-wallet](skills/pionex-wallet/SKILL.md) | Full portfolio overview: USDT/BTC total across all account types (spot + bots + dual investment) | Yes |
 | [pionex-trade](skills/pionex-trade/SKILL.md) | Spot orders: place, cancel, open orders, fills | Yes |
 | [pionex-bot](skills/pionex-bot/SKILL.md) | Futures Grid, Spot Grid & Smart Copy Bot lifecycle: get/create/check_params/adjust/reduce/cancel; Spot Grid also supports get_ai_strategy, invest_in, profit; Signal provider subscription via `bot signal listener` | Yes |
 | [pionex-earn-dual](skills/pionex-earn-dual/SKILL.md) | Dual Investment: products, prices, invest, revoke, collect | No (public) / Yes (private) |

--- a/docs/requirements-overview.md
+++ b/docs/requirements-overview.md
@@ -4,7 +4,7 @@ This document summarizes the requirement history and current status of the Pione
 
 ## Last Updated
 
-**Date:** 2026-04-14 (updated by iteration `2026041400_bot_smart_copy`)
+**Date:** 2026-05-08 (updated by iteration `2026050800_wallet_balance_full`)
 
 ## Current Status
 
@@ -26,6 +26,12 @@ This document summarizes the requirement history and current status of the Pione
 **Scope:** Spot account balance queries — requires API credentials
 
 - ✅ `account balance` — All spot balances
+
+#### Skill: pionex-wallet
+**Status:** Completed  
+**Scope:** Full portfolio overview (all account types) — requires API credentials
+
+- ✅ `wallet balance_full` — Grand total in USDT/BTC + per-type breakdown (futures lite bots, spot balances, dual investment, Pionex Card, trader account)
 
 #### Skill: pionex-trade
 **Status:** Completed  
@@ -102,6 +108,11 @@ Each skill must:
 4. Include `--dry-run` instructions for destructive commands
 
 ## Iteration History
+
+### 2026-05-08: Wallet Balance Full
+**Iteration Directory:** `specs/2026050800_wallet_balance_full/`
+**Requirements:** Add new `pionex-wallet` skill wrapping `wallet balance_full` — full portfolio overview with USDT/BTC grand total and per-account-type breakdown (spot, futures lite bots, dual investment, Pionex Card, trader account)
+**Source:** CLI implementation in `pionex-ai-kit` issue #31
 
 ### 2026-04-14: Smart Copy Bot
 **Iteration Directory:** `specs/2026041400_bot_smart_copy/`

--- a/docs/tech-api-overview.yaml
+++ b/docs/tech-api-overview.yaml
@@ -47,6 +47,16 @@ x-cli-interface:
         - name: "account balance"
           description: "All spot balances. Returns JSON array; filter by currency client-side."
 
+    wallet:
+      auth_required: true
+      commands:
+        - name: "wallet balance_full"
+          flags: ["--app-lang <lang>  # en or zh, optional"]
+          description: >
+            Full portfolio overview. Returns totalInUsdt/totalInBtc grand totals plus
+            botAccount.detail[] breakdown by type (futures_lite, spot, dual_manual,
+            pionex_card), traderAccount, extractBalances, and live coin prices.
+
     orders:
       auth_required: true
       commands:

--- a/docs/tech-memory-overview.md
+++ b/docs/tech-memory-overview.md
@@ -4,7 +4,7 @@ This document records key decisions, lessons learned, and non-obvious technical 
 
 ## Last Updated
 
-**Date:** 2026-04-14
+**Date:** 2026-05-08
 
 ---
 
@@ -190,3 +190,27 @@ Initial docs were based on an earlier version of the PR. After reviewing commit 
 **`smart_copy cancel` completely redesigned** — `--close-sell-model` removed. New flags: `--close-note` (string) and `--convert-into-earn-coin` (boolean, no value).
 
 **`bot signal listener` is provider-side, not consumer-side** — pushes a trading signal event to the Pionex signal platform. It is NOT a subscription command. Required fields: `--signal-type`, `--signal-param`, `--base`, `--quote`, `--time` (RFC 3339), `--price`, `--action`, `--position-size`, `--contracts`.
+
+---
+
+## Iteration: 2026050800_wallet_balance_full (2026-05-08)
+
+**Added:** `skills/pionex-wallet/SKILL.md` — new skill for full portfolio overview
+
+### Key Decisions
+
+**1. New skill `pionex-wallet` instead of extending `pionex-portfolio`**
+
+`pionex-portfolio` wraps `account balance` (raw per-coin spot list). `wallet balance_full` returns a cross-account aggregated view with USDT/BTC totals — a fundamentally different output shape and user intent. Merging them would blur the routing boundary and cause the skill router to misfire on "how much USDT do I have?" vs "what's my total portfolio?".
+
+**2. `botAccount.detail[].type` values are stable enum-like strings**
+
+As of 2026-05-08, observed types: `futures_lite`, `spot`, `dual_manual`, `pionex_card`. The skill documents these in the output guide without asserting exhaustiveness — new types may appear as Pionex adds products.
+
+**3. `--app-lang` flag is optional and cosmetic**
+
+It only affects `title` display strings (e.g. "Futures Lite" vs Chinese equivalent). It does not change numeric fields or JSON structure. The skill documents it but does not require the agent to set it.
+
+**4. No `--dry-run` needed — read-only command**
+
+`wallet balance_full` is a GET operation with no side effects. Safety constraints only apply to write commands.

--- a/skills/pionex-wallet/SKILL.md
+++ b/skills/pionex-wallet/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pionex-wallet
+description: >
+  Use when the user asks for their total Pionex portfolio value, full balance
+  overview across all account types (spot + bots + dual investment + trader
+  account), USDT/BTC grand total, or wants to know how much they have in bots
+  vs spot. Read-only; requires API credentials. For spot coin list only, use
+  pionex-portfolio instead.
+license: MIT
+metadata:
+  author: pionex
+  version: "1.0.0"
+  agent:
+    requires:
+      bins: ["pionex-trade-cli"]
+    install:
+      - id: npm
+        kind: node
+        package: "@pionex/pionex-ai-kit"
+        bins: ["pionex-trade-cli", "pionex-ai-kit"]
+        label: "Install pionex CLI (npm)"
+---
+
+# Pionex Wallet Skill
+
+Query the full Pionex portfolio overview: total USDT/BTC value across all account types. Requires API credentials (`pionex-ai-kit onboard`).
+
+## When to use
+
+- User asks: total portfolio value, overall balance, "how much is my whole Pionex account worth", "spot + bot total", breakdown by account type (bots vs spot vs dual investment).
+- User wants a consolidated view — not just spot coins, not just one bot.
+
+## Command
+
+| Command | Type | Description |
+|---------|------|-------------|
+| `pionex-trade-cli wallet balance_full` | READ | Full portfolio overview: USDT/BTC grand total + per-account-type breakdown. |
+| `pionex-trade-cli wallet balance_full --app-lang en` | READ | Same, force English display names in `title` fields. |
+
+No write operations — `--dry-run` is not applicable.
+
+## Prerequisites
+
+```bash
+npm install -g @pionex/pionex-ai-kit
+pionex-ai-kit onboard
+```
+
+## Output Structure
+
+```json
+{
+  "result": true,
+  "data": {
+    "totalInUsdt": "<grand total in USDT>",
+    "totalInBtc":  "<grand total in BTC>",
+    "botAccount": {
+      "totalInUsdt": "<all bot types combined>",
+      "detail": [
+        { "type": "futures_lite", "title": "Futures Lite",    "totalInUsdt": "...", "count": 1 },
+        { "type": "spot",         "title": "Spot Balances",   "totalInUsdt": "..." },
+        { "type": "dual_manual",  "title": "Dual investment", "totalInUsdt": "..." },
+        { "type": "pionex_card",  "title": "Pionex Card",     "totalInUsdt": "..." }
+      ]
+    },
+    "traderAccount": { "title": "Trader Account", "totalInUsdt": "..." },
+    "extractBalances": {
+      "propTrading":      { "totalInUsdt": "..." },
+      "trialFundCoupon":  { "totalInUsdt": "..." }
+    },
+    "prices": { "btc": "...", "eth": "...", "usdt": "1", ... }
+  }
+}
+```
+
+### How to summarize the output
+
+1. Report `data.totalInUsdt` and `data.totalInBtc` as the grand total.
+2. For a breakdown, iterate `data.botAccount.detail` — report each `title` + `totalInUsdt`.
+3. Include `data.traderAccount.totalInUsdt` if non-zero.
+4. Skip `data.prices` and `data.extractBalances` unless the user explicitly asks.
+5. Round to 2 decimal places for display.
+
+## Skill routing
+
+| Scope | Skill |
+|-------|-------|
+| Total portfolio / full overview | **pionex-wallet** (this skill) |
+| Spot coin list (per-coin balances) | **pionex-portfolio** |
+| Market prices only | **pionex-market** |
+| Place / cancel spot orders | **pionex-trade** |
+| Futures/Spot Grid Bot lifecycle | **pionex-bot** |
+
+## Example
+
+- User: "What's my total Pionex account value?"
+- Agent: run `pionex-trade-cli wallet balance_full`, then report:
+  > Total: **$3,958.80** (≈ 0.0494 BTC)
+  > - Futures Lite bots: $3,928.24
+  > - Spot Balances: $0.49
+  > - Dual Investment: $30.06
+  > - Pionex Card: $0.00

--- a/specs/2026050800_wallet_balance_full/1-requirements.md
+++ b/specs/2026050800_wallet_balance_full/1-requirements.md
@@ -1,0 +1,39 @@
+# Requirements: pionex-wallet Skill (wallet balance_full)
+
+## Background
+
+The `pionex-trade-cli wallet balance_full` command was added in `pionex-ai-kit` (issue #31). It returns a unified view of the user's total Pionex portfolio across spot balances, bot accounts (futures lite, spot grid, dual investment, Pionex Card), trader accounts, and extract balances — including live USDT/BTC totals.
+
+The existing `pionex-portfolio` skill only covers `account balance` (raw spot coin list). There is no skill for the cross-account total balance view, leaving agents without a way to answer questions like "what is my total Pionex value?" or "how much do I have in bots vs spot?"
+
+## Requirements
+
+### New Skill: `pionex-wallet`
+
+Create `skills/pionex-wallet/SKILL.md` with:
+
+1. **Routing description** — trigger on: total balance, full balance overview, portfolio value, bot account value, spot + futures total, "how much is my whole Pionex account worth".
+2. **Single command table** — `pionex-trade-cli wallet balance_full [--app-lang <lang>]`
+3. **Output interpretation guide** — explain the JSON structure so the agent can format a readable summary for the user:
+   - `totalInUsdt` / `totalInBtc` — grand total
+   - `botAccount.detail[]` — per-type breakdown (futures_lite, spot, dual_manual, pionex_card)
+   - `traderAccount` — prop-trading account value
+   - `extractBalances` — extra balance buckets (propTrading, trialFundCoupon)
+   - `prices` — live coin prices used for calculation
+4. **Skill routing** — clear boundary with `pionex-portfolio` (spot coins only) and when to use each.
+
+### Documentation Updates
+
+- `README.md` — add `pionex-wallet` row to the Skills table.
+- `CLAUDE.md` — add `pionex-wallet` row to the Skill Routing Map table.
+- `docs/requirements-overview.md` — append new skill section and iteration history entry.
+- `docs/tech-memory-overview.md` — append iteration knowledge entry.
+- `docs/tech-api-overview.yaml` — add `wallet balance_full` command entry.
+
+## Acceptance Criteria
+
+1. `skills/pionex-wallet/SKILL.md` exists with valid YAML frontmatter (`name: pionex-wallet`).
+2. Skill routing description correctly distinguishes from `pionex-portfolio`.
+3. README.md Skills table includes `pionex-wallet` row.
+4. CLAUDE.md Skill Routing Map includes `pionex-wallet` row.
+5. `docs/requirements-overview.md` has `pionex-wallet` skill section.

--- a/specs/2026050800_wallet_balance_full/3-tech-design.md
+++ b/specs/2026050800_wallet_balance_full/3-tech-design.md
@@ -1,0 +1,89 @@
+# Tech Design: pionex-wallet Skill
+
+## Overview
+
+Add a new skill `pionex-wallet` that wraps the `wallet balance_full` CLI command. This is a read-only skill with no write operations.
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `skills/pionex-wallet/SKILL.md` | **CREATE** — new skill file |
+| `README.md` | **MODIFY** — add row to Skills table |
+| `CLAUDE.md` | **MODIFY** — add row to Skill Routing Map |
+| `docs/requirements-overview.md` | **MODIFY** — add skill section + iteration history |
+| `docs/tech-memory-overview.md` | **MODIFY** — append iteration entry |
+| `docs/tech-api-overview.yaml` | **MODIFY** — add wallet balance_full command |
+
+## Skill File Design
+
+```yaml
+---
+name: pionex-wallet
+description: >
+  Use when the user asks for their total Pionex portfolio value, full balance
+  overview across all account types (spot + bots + dual investment + trader
+  account), or wants to know how much they have in bots vs spot.
+  Read-only; requires API credentials. For spot coin list only, use
+  pionex-portfolio instead.
+license: MIT
+metadata:
+  author: pionex
+  version: "1.0.0"
+  agent:
+    requires:
+      bins: ["pionex-trade-cli"]
+    install:
+      - id: npm
+        kind: node
+        package: "@pionex/pionex-ai-kit"
+        bins: ["pionex-trade-cli", "pionex-ai-kit"]
+        label: "Install pionex CLI (npm)"
+---
+```
+
+## CLI Command
+
+```
+pionex-trade-cli wallet balance_full [--app-lang <lang>]
+```
+
+- `--app-lang` — optional; `en` or `zh`. Controls display names in the response (e.g. `title` fields). Defaults to system language.
+- No write operations → no `--dry-run` needed.
+
+## Output JSON Structure
+
+```json
+{
+  "result": true,
+  "timestamp": 1778242190875,
+  "data": {
+    "totalInUsdt": "3958.79...",
+    "totalInBtc": "0.04938...",
+    "botAccount": {
+      "totalInUsdt": "...",
+      "detail": [
+        { "type": "futures_lite", "title": "Futures Lite", "totalInUsdt": "...", "count": 1, "list": [...] },
+        { "type": "spot",         "title": "Spot Balances", "totalInUsdt": "...", "list": [...] },
+        { "type": "dual_manual",  "title": "Dual investment", "totalInUsdt": "...", "list": [...] },
+        { "type": "pionex_card",  "title": "Pionex Card", "totalInUsdt": "...", "list": [...] }
+      ]
+    },
+    "traderAccount": { "title": "...", "totalInUsdt": "...", "detail": [...] },
+    "extractBalances": { "propTrading": {...}, "trialFundCoupon": {...} },
+    "prices": { "usdt": "1", "btc": "...", ... }
+  }
+}
+```
+
+## Skill Routing Boundary
+
+| Question | Skill |
+|----------|-------|
+| "Total portfolio value", "spot + bot total" | **pionex-wallet** |
+| "How much USDT/BTC/coin in spot?" | **pionex-portfolio** |
+| "Current price of BTC?" | **pionex-market** |
+
+## Version
+
+`1.0.0` — new skill (no prior version to bump from).

--- a/specs/2026050800_wallet_balance_full/4-tasks.md
+++ b/specs/2026050800_wallet_balance_full/4-tasks.md
@@ -1,0 +1,48 @@
+# Tasks: pionex-wallet Skill
+
+## Task 1: Create `skills/pionex-wallet/SKILL.md`
+
+**Output:** `skills/pionex-wallet/SKILL.md` exists with valid frontmatter and full content.
+
+**Verification:** `cat skills/pionex-wallet/SKILL.md` — frontmatter parses, command table present, output guide present.
+
+---
+
+## Task 2: Update `README.md` Skills table
+
+Add `pionex-wallet` row after `pionex-portfolio`.
+
+**Verification:** `grep pionex-wallet README.md` returns a row.
+
+---
+
+## Task 3: Update `CLAUDE.md` Skill Routing Map
+
+Add `pionex-wallet` row to the Skill Routing Map table.
+
+**Verification:** `grep pionex-wallet CLAUDE.md` returns a row.
+
+---
+
+## Task 4: Update `docs/requirements-overview.md`
+
+- Add `#### Skill: pionex-wallet` section under Core Features.
+- Append iteration history entry.
+
+**Verification:** section present with ✅ checklist.
+
+---
+
+## Task 5: Update `docs/tech-memory-overview.md`
+
+Append iteration entry for `2026050800_wallet_balance_full`.
+
+**Verification:** entry appended with key decisions.
+
+---
+
+## Task 6: Update `docs/tech-api-overview.yaml`
+
+Add `wallet balance_full` command under `x-cli-interface`.
+
+**Verification:** `grep balance_full docs/tech-api-overview.yaml` returns a match.


### PR DESCRIPTION
Add new `pionex-wallet` skill wrapping `wallet balance_full` command, which returns USDT/BTC grand totals across all account types (spot, futures lite bots, dual investment, Pionex Card, trader account).

Update README, CLAUDE.md, and docs/ to reflect the new skill.